### PR TITLE
server.Addpath()return-non-empty-uuid

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1289,7 +1289,7 @@ func (s *BgpServer) AddPath(vrfId string, pathList []*table.Path) (uuidBytes []b
 		s.propagateUpdate(nil, pathList)
 		return nil
 	}, true)
-	return
+	return pathList[0].UUID().Bytes(), err
 }
 
 func (s *BgpServer) DeletePath(uuid []byte, f bgp.RouteFamily, vrfId string, pathList []*table.Path) error {


### PR DESCRIPTION
Hi.

This pull request is under snipet solutions.
https://gist.github.com/nao4arale/942c4e9465387f5fda9227da00495e86

go run this snipet,

```bash
go run main.go
Added a route's UUID is,  00000000-0000-0000-0000-000000000000
Show a route's UUID is,   81c8ba72-2362-4eb0-849b-e73cec34be8d
```

Why Addpath() return empty []bytes?
If this IsPloblem & NOT Intend things, please pull.
After change code, go run this snipet,

```bash
go run main.go
Added a route's UUID is,  714a87ee-b990-4e6e-9db6-8114171c753a
Show a route's UUID is,   714a87ee-b990-4e6e-9db6-8114171c753a
```

That's Grate? :wink: